### PR TITLE
Update module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/do-community/do-ansible-inventory
+module github.com/do-community/hacktoberfest-repo-topic-apply
 
 go 1.14
 


### PR DESCRIPTION
Makes it go get-able. Currently:

```
$ go get github.com/do-community/hacktoberfest-repo-topic-apply
go: downloading github.com/do-community/hacktoberfest-repo-topic-apply v0.0.0-20201002212613-403d0672bb88
go: github.com/do-community/hacktoberfest-repo-topic-apply upgrade => v0.0.0-20201002212613-403d0672bb88
go get: github.com/do-community/hacktoberfest-repo-topic-apply@v0.0.0-20201002212613-403d0672bb88: parsing go.mod:
	module declares its path as: github.com/do-community/do-ansible-inventory
	        but was required as: github.com/do-community/hacktoberfest-repo-topic-apply
```