### PR TITLE
Add flag for choosing which repo type

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ Flags:
       --topic="hacktoberfest"  topic to add to repos
   -r, --remove                 Remove hacktoberfest topic from all repos Default false
   -l, --labels                 Add spam, invalid, and hacktoberfest-accepted labels to repo. Default true
- ```
+      --type=public            Type of repo to filter to
+```

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	topic       = kingpin.Flag("topic", "topic to add to repos").Default("hacktoberfest").String()
 	remove      = kingpin.Flag("remove", "Remove hacktoberfest topic from all repos").Short('r').Default("false").Bool()
 	labels      = kingpin.Flag("labels", "Add spam, invalid, and hacktoberfest-accepted labels to repo").Short('l').Default("true").Bool()
+	repotype    = kingpin.Flag("type", "Type of repo to filter to").HintOptions("public", "forks").Default("public").Enum("public", "private", "forks", "sources", "member", "internal")
 )
 
 func main() {
@@ -68,7 +69,7 @@ func main() {
 
 	if *githubOrg != "" {
 		owner = *githubOrg
-		opt := &github.RepositoryListByOrgOptions{Type: "public"}
+		opt := &github.RepositoryListByOrgOptions{Type: *repotype}
 		var err error
 		repos, _, err = client.Repositories.ListByOrg(ctx, owner, opt)
 		if err != nil {
@@ -76,7 +77,7 @@ func main() {
 		}
 	} else if *githubUser != "" {
 		owner = *githubUser
-		opt := &github.RepositoryListOptions{Type: "public"}
+		opt := &github.RepositoryListOptions{Type: *repotype}
 		var err error
 		repos, _, err = client.Repositories.List(ctx, owner, opt)
 		if err != nil {


### PR DESCRIPTION
Btw, I can't get the kingpin to include the list of allowed items in the help

The original kingpin author has moved onto kong(https://github.com/alecthomas/kong) so it might be worth down the line seeing if produces a nicer output