### PR TITLE
Disallow forks and private by default, but allow by flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,7 @@ Flags:
   -p, --topic="hacktoberfest"  topic to add to repos
   -r, --remove                 Remove hacktoberfest topic from all repos
   -l, --labels                 Add spam, invalid, and hacktoberfest-accepted labels to repo
-      --type=public            Type of repo to filter to. Options: public, private, forks, sources, member, internal
+      --include-forks          Include forks
+      --include-private        Include private repos
+
 ```

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 			}
 		}
 
-		if *includePrivate == true {
+		if *includePrivate == false {
 			if *repo.Private == true {
 				loggerWithFields.Info("skipping private")
 				continue


### PR DESCRIPTION
so related to #9 

Type allows different values depending on which version of docs you look
at. So Simplified the checks to just be able to exclude anything you don't
want.

I could default excludeForks to true, but then to disable it you'd have to use --no-excludeForks which isn't documented by --help

Let me know