### PR TITLE
Fetch only needed repos in ListByOrg

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 		}
 	}
 	if *githubUser != "" {
-		opt := &github.RepositoryListOptions{Type: "public"}
+		opt := &github.RepositoryListOptions{Type: "all"}
 		for {
 			var repos, resp, err = client.Repositories.List(ctx, *githubUser, opt)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	var allRepos []*github.Repository
 
 	if *githubOrg != "" {
-		opt := &github.RepositoryListByOrgOptions{Type: "all"}
+		opt := &github.RepositoryListByOrgOptions{Type: "public"}
 		for {
 			var repos, resp, err = client.Repositories.ListByOrg(ctx, *githubOrg, opt)
 			if err != nil {
@@ -80,9 +80,39 @@ func main() {
 			}
 			opt.Page = resp.NextPage
 		}
+		if *includeForks == true {
+			opt := &github.RepositoryListByOrgOptions{Type: "forks"}
+			for {
+				var repos, resp, err = client.Repositories.ListByOrg(ctx, *githubOrg, opt)
+				if err != nil {
+					log.WithError(err).Fatalf("issue getting repositories")
+					break
+				}
+				allRepos = append(allRepos, repos...)
+				if resp.NextPage == 0 {
+					break
+				}
+				opt.Page = resp.NextPage
+			}
+		}
+		if *includePrivate == true {
+			opt := &github.RepositoryListByOrgOptions{Type: "private"}
+			for {
+				var repos, resp, err = client.Repositories.ListByOrg(ctx, *githubOrg, opt)
+				if err != nil {
+					log.WithError(err).Fatalf("issue getting repositories")
+					break
+				}
+				allRepos = append(allRepos, repos...)
+				if resp.NextPage == 0 {
+					break
+				}
+				opt.Page = resp.NextPage
+			}
+		}
 	}
 	if *githubUser != "" {
-		opt := &github.RepositoryListOptions{Type: "all"}
+		opt := &github.RepositoryListOptions{Type: "public"}
 		for {
 			var repos, resp, err = client.Repositories.List(ctx, *githubUser, opt)
 			if err != nil {


### PR DESCRIPTION
fixes part of #26 

First, fetch only public repos.
After that, fetch private or folks repos if needed.

Github API Docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-organization-repositories